### PR TITLE
Change slashing mechanics

### DIFF
--- a/test/subscriptions/BaseTest.t.sol
+++ b/test/subscriptions/BaseTest.t.sol
@@ -16,9 +16,7 @@ abstract contract BaseTest is Test {
     event RewardWithdraw(address indexed account, uint256 tokensTransferred);
 
     /// @dev Emitted when a subscriber slashed the rewards of another subscriber
-    event RewardPointsSlashed(
-        address indexed account, address indexed slasher, uint256 rewardPointsSlashed, uint256 rewardPointsEarned
-    );
+    event RewardPointsSlashed(address indexed account, address indexed slasher, uint256 rewardPointsSlashed);
 
     /// @dev Emitted when time is purchased (new nft or renewed)
     event Purchase(


### PR DESCRIPTION
1. Remove the reward point split of 70/30. There is no price discovery, and the pure deflationary slash has incentives for the caller and further benefits the subscriber base.
2. Revert slash when reward allocation is disabled