### PR TITLE
[STP] QS-SUB6 Native Token Recovery

### DIFF
--- a/test/mocks/SelfDestruct.sol
+++ b/test/mocks/SelfDestruct.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+contract SelfDestruct {
+    function destroy(address recipient) public payable {
+        selfdestruct(payable(recipient));
+    }
+}


### PR DESCRIPTION
This addresses an issue where tokens could be locked in the contract if they were sent in a way that bypasses external calls or the receive function, such as self-destruct.

* Add recoverNativeTokens function for transferring unexpected funds to a recipient
* Add reconcileNativeBalance to account for unexpected funds