### PR TITLE
[STP] Allocate fees and rewards at mint time

### DIFF
--- a/test/subscriptions/SubscriptionTokenV1.t.sol
+++ b/test/subscriptions/SubscriptionTokenV1.t.sol
@@ -266,11 +266,12 @@ contract SubscriptionTokenV1Test is BaseTest {
 
         // Send eth to contract while refunding
         vm.expectEmit(true, true, false, true, address(stp));
-        emit RefundTopUp(1e18);
+        emit RefundTopUp(2e18);
         vm.expectEmit(true, true, false, true, address(stp));
         emit Refund(alice, 1, 1e18, 1e18 / 2);
-        stp.refund{value: 1e18}(1e18, list(alice));
-        assertEq(0, address(stp).balance);
+        stp.refund{value: 2e18}(2e18, list(alice));
+        assertEq(1e18, address(stp).balance);
+        assertEq(1e18, stp.creatorBalance());
         vm.stopPrank();
     }
 

--- a/test/subscriptions/SubscriptionTokenV1Fee.t.sol
+++ b/test/subscriptions/SubscriptionTokenV1Fee.t.sol
@@ -21,13 +21,16 @@ contract SubscriptionTokenV1FeeTest is BaseTest {
 
         assertEq(bps, 500);
         assertEq(recipient, fees);
-        mint(alice, 1e18);
 
         uint256 expectedFee = (1e18 * 500) / 10000;
         uint256 balance = creator.balance;
 
+        vm.startPrank(alice);
         vm.expectEmit(true, true, false, true, address(stp));
         emit FeeAllocated(expectedFee);
+        stp.mint{value: 1e18}(1e18);
+        vm.stopPrank();
+
         withdraw();
 
         assertEq(creator.balance, balance + (1e18 - expectedFee));


### PR DESCRIPTION
Rather than allocate fees and rewards at withdraw time, move fund paritioning to purchase.

This increases liquidity for the fee collector and reward point holders, prevents frozen fees and rewards, and also eliminates fees on refunds where top-up value exceeds refunded value.