### PR TITLE
[STP] QS Redesign slashing mechanism

### DIFF
--- a/test/subscriptions/SubscriptionTokenV1.t.sol
+++ b/test/subscriptions/SubscriptionTokenV1.t.sol
@@ -99,8 +99,11 @@ contract SubscriptionTokenV1Test is BaseTest {
         stp.mint{value: 1e18}(1e18);
         assertEq(address(stp).balance, 1e18);
         assertEq(stp.balanceOf(alice), 5e17);
-        (uint256 tokenId,,,) = stp.subscriptionOf(alice);
+        (uint256 tokenId, uint256 numSeconds, uint256 points, uint256 expires) = stp.subscriptionOf(alice);
         assertEq(stp.ownerOf(tokenId), alice);
+        assertEq(numSeconds, 1e18 / 2);
+        assertEq(points, 0);
+        assertEq(expires, block.timestamp + (1e18 / 2));
         assertEq(stp.tokenURI(1), "turi");
     }
 
@@ -159,10 +162,12 @@ contract SubscriptionTokenV1Test is BaseTest {
     }
 
     function testMintExpire() public prank(alice) {
+        uint256 time = block.timestamp;
         stp.mint{value: 1e18}(1e18);
         vm.warp(block.timestamp + 6e17);
         assertEq(stp.balanceOf(alice), 0);
-        (uint256 tokenId,,,) = stp.subscriptionOf(alice);
+        (uint256 tokenId,,, uint256 expires) = stp.subscriptionOf(alice);
+        assertEq(expires, time + 1e18 / 2);
         assertEq(stp.ownerOf(tokenId), alice);
     }
 


### PR DESCRIPTION
Slashing points proportially to inactive time resulted in truncation issues between slashed points and withdraws due to differing resolution. While the impact may have been minimal, it was imperfect and increased uncertainty.

This model is simple: Points can be slashed once for a given account, after a grace period which is 50% of their total purchased time. If an account subscribes, in aggregate, for 6 months, then their grace period is 3 months. After the grace period, their reward points can be slashed. If they renew before the slash point, the slash point is reset.

Additionally, the slashing point will factor in grants, but only if grant time is active.